### PR TITLE
MacOS compat: use objdump -t instead of -T

### DIFF
--- a/src/link.sh
+++ b/src/link.sh
@@ -18,7 +18,7 @@ OD=`which objdump 2>/dev/null`
 [ -n "$OD" ] || OD=`which llvm-objdump 2>/dev/null`
 [ -n "$OD" ] || die "objdump not found"
 
-FLG=$($OD -T $L | grep _shm_flags | sed -E 's/0*([^ ]+) .+/0x\1/')
+FLG=$($OD -t $L | grep '\*ABS\*.*_shm_flags' | sed -E 's/0*([^ ]+) .+/0x\1/')
 CMD="$LNK -d $D $L -f $FLG -o $O $*"
 echo $CMD
 $CMD


### PR DESCRIPTION
-T does not work on Mac; -t works on both Linux and MacOS but returns two matches; if we grep for *ABS* we get the correct one.