### PR TITLE
deb,rpm: drop djstub dep

### DIFF
--- a/comcom64.spec.rpkg
+++ b/comcom64.spec.rpkg
@@ -17,7 +17,6 @@ Source0: {{{ git_dir_archive }}}
 BuildRequires: make
 BuildRequires: pkgconf-pkg-config
 BuildRequires: thunk-gen
-BuildRequires: djstub
 BuildRequires: dj64dev-dj64-devel
 BuildRequires: git
 BuildRequires: grep

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,6 @@ Build-Depends:
     make,
     pkgconf,
     thunk-gen,
-    djstub,
     dj64-dev,
     git,
     grep,


### PR DESCRIPTION
This dep is problematic for some users, see
https://github.com/dosemu2/dosemu2/issues/2491